### PR TITLE
Support alternative import statements

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -215,3 +215,33 @@ test('handles pragma statement not ending in semicolon', t => {
   const { solidity } = getMetadata(`pragma solidity ^0.5.0`);
   t.deepEqual(solidity, ["^0.5.0"]);
 });
+
+test('import all from file', t => {
+  const { imports } = getMetadata(`import * as token from "./token.sol"; contract Foo { }`);
+  t.deepEqual(imports, ["./token.sol"]);
+});
+
+test('import aliased file', t => {
+  const { imports } = getMetadata(`import "./token.sol" as token; contract Foo { }`);
+  t.deepEqual(imports, ["./token.sol"]);
+});
+
+test('import single from file', t => {
+  const { imports } = getMetadata(`import { token } from "./token.sol"; contract Foo { }`);
+  t.deepEqual(imports, ["./token.sol"]);
+});
+
+test('import single with alias from file', t => {
+  const { imports } = getMetadata(`import { token as erc20 } from "./token.sol"; contract Foo { }`);
+  t.deepEqual(imports, ["./token.sol"]);
+});
+
+test('import multiple from file', t => {
+  const { imports } = getMetadata(`import { token, crowdsale } from "./token.sol"; contract Foo { }`);
+  t.deepEqual(imports, ["./token.sol"]);
+});
+
+test('import multiple with aliases from file', t => {
+  const { imports } = getMetadata(`import { token as erc20, crowdsale as ico } from "./token.sol"; contract Foo { }`);
+  t.deepEqual(imports, ["./token.sol"]);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,14 +101,38 @@ export class Parser {
   consumeImport(): Token {
     this.consumeLiteral('import');
     this.consumeWhitespace();
+    
+    // import { foo, bar as baz } from 'file';
     if (this.peek('{')) {
       this.consumeBlock('{', '}');
       this.consumeWhitespace();
       this.consumeLiteral('from');
       this.consumeWhitespace();
+    } 
+    // import * as foo from 'file';
+    else if (this.peek('*')) {
+      this.consumeLiteral('*');
+      this.consumeWhitespace();
+      this.consumeLiteral('as');
+      this.consumeWhitespace();
+      this.consumeIdentifier();
+      this.consumeWhitespace();
+      this.consumeLiteral('from');
+      this.consumeWhitespace();
     }
+    
+    // Consume filename
     const value = this.consumeString();
     this.consumeWhitespace();
+    
+    // import 'file' as foo;
+    if (this.peek('as')) {
+      this.consumeLiteral('as');
+      this.consumeWhitespace();
+      this.consumeIdentifier();
+      this.consumeWhitespace();
+    }
+
     this.consumeChar(';');
     return {
       kind: TokenKind.Import,
@@ -223,6 +247,7 @@ export class Parser {
       if (/[a-zA-Z0-9$_]/.test(char)) {
         value += char;
       } else {
+        this.index -= 1;
         break;
       }
     }


### PR DESCRIPTION
Add support for:
```
import * as foo from 'file';
import 'file' as foo;
```